### PR TITLE
Cshrcp 937 add health check

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -8,6 +8,15 @@ var app = require('../app');
 var debug = require('debug')('candidate-interface-ui:server');
 var http = require('http');
 require('colors');
+const terminus = require('@godaddy/terminus');
+const apiClient = require('../lib/modules/apiClient');
+
+
+async function onHealthCheck() {
+  const result = await apiClient.health.check();
+  return await apiClient.health.check();
+};
+
 
 /**
  * Get port from environment and store in Express.
@@ -23,9 +32,17 @@ app.set('port', port);
 var server = http.createServer(app);
 
 /**
+* Add health check to server
+*/
+const options = {signal: 'SIGINT',
+   healthChecks: {
+    '/healthcheck': onHealthCheck,
+  }};
+terminus(server, options);
+
+/**
  * Listen on provided port, on all network interfaces.
  */
-
 server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);

--- a/lib/modules/apiClient/index.js
+++ b/lib/modules/apiClient/index.js
@@ -21,6 +21,15 @@ apiClient.vacancy = {
     getById: id => request(`/vacancy/${id}`),
 };
 
+apiClient.health = {
+    check: () => {
+        const reqOptions = {
+            timeout: 200,
+        };
+        return request('/department?size=999', reqOptions);
+    },
+};
+
 module.exports = apiClient;
 
 // private functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -273,6 +273,15 @@
         "arrify": "1.0.1"
       }
     },
+    "@godaddy/terminus": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-2.2.0.tgz",
+      "integrity": "sha512-olNnWo38hBYEGGGUp1YLpZSNpyjk8iywrF5KpWNcVcywy4CeD+sO/TwO/kEfRw75g6oRw1TmN8tDaL8r4kcY0w==",
+      "requires": {
+        "es6-promisify": "5.0.0",
+        "stoppable": "1.0.6"
+      }
+    },
     "@ladjs/time-require": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@ladjs/time-require/-/time-require-0.1.4.tgz",
@@ -3623,6 +3632,19 @@
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
       }
     },
     "es6-set": {
@@ -10852,6 +10874,11 @@
           }
         }
       }
+    },
+    "stoppable": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.0.6.tgz",
+      "integrity": "sha512-d1B/3QXeT2+MixdC+EqQ9/llq3yvZkdsh8hrML52NmememiIAus0MBsnebYmzojJ2Ls5drhDqo2PFH1FLx2DWA=="
     },
     "stream-browserify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test"
   ],
   "dependencies": {
+    "@godaddy/terminus": "^2.2.0",
     "babel-polyfill": "^6.26.0",
     "body-parser": "~1.18.2",
     "compression": "^1.7.1",


### PR DESCRIPTION
__What__

This pull request adds a very simple HealthCheck to the Node.js app to allow us to monitor application health externally and support deployment to PaaS / Kubernettes environments.

__How to test__

1. Check out this branch
2. Run `npm install` to add dependencies
3. Set an API_URL env varible locally that works correctly
4. Run the app and then visit 'http://localhost:3000/healthcheck'
5. You should see a http 200 response and status ok returned as a json object.
6. Unset the API_URL env variable
7. Rerun the application and check the healthcheck
8. The Healthcheck should respond with an error

