### PR TITLE
Add Cloudfoundry support & deployment task to app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ stop:
 test:
 	@docker-compose run --rm app npm run test
 
-deploy-staging: ;@echo "🚀......Deploying to STAGING........🚀";\
-	              cf push rpg-ci -f manifest.staging.yml ;\
-	              echo "Updating environment variables using LOCAL .env file" ;\
-	              cat .env |sed 's/=/ /'| xargs -t -I % sh -c 'cf set-env rpg-ci %';\
+deploy-staging: ;@echo "🚀......Deploying to STAGING........🚀" &&\
+	              cf push rpg-ci -f manifest.staging.yml &&\
+	              echo "Updating environment variables using LOCAL .env file" &&\
+	              cat .env |sed 's/=/ /'| xargs -t -I % sh -c 'cf set-env rpg-ci %' &&\
               	cf restage rpg-ci

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,9 @@ stop:
 
 test:
 	@docker-compose run --rm app npm run test
+
+deploy-staging: ;@echo "🚀......Deploying to STAGING........🚀";\
+	              cf push rpg-ci -f manifest.staging.yml ;\
+	              echo "Updating environment variables using LOCAL .env file" ;\
+	              cat .env |sed 's/=/ /'| xargs -t -I % sh -c 'cf set-env rpg-ci %';\
+              	cf restage rpg-ci

--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ Run `npm run dev`
 
 ## Running Tests
 Run `npm run test`
+
+
+## Manual deploy to Government PaaS
+
+### Prerequisites
+
+1. Install the CloudFoundry CLI tool
+2. Login to the Government PaaS instance and space you wish to deploy to.
+
+### How to deploy
+
+*Note* This deployment method uses your local `.env` file to populate environment
+variables on CloudFoundry. You __must__ ensure that you have the correct set of
+variables for the correct environment set in that file.
+
+To push to the staging environment run: `make deploy-staging`
+
+This will push to the application `rpg-ci`, making use of the local staging
+cf manifest (`manifest.staging.yml`) and set a bunch of environment variables
+currently set in your local `.env` file.

--- a/manifest.staging.yml
+++ b/manifest.staging.yml
@@ -1,0 +1,13 @@
+---
+applications:
+  - name: rpg-candidate-interface
+    memory: 1G
+    instances: 1
+    buildpack: nodejs_buildpack
+    command: "npm start"
+    env:
+      NODE_VERSION: "9.8.0"
+      NODE_ENV: staging
+      API_URL: ""
+      AUTH_USERNAME: ""
+      AUTH_PASSWORD: ""

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rpg-candidate-interface-ui",
   "version": "0.0.0",
   "private": true,
+  "engines": {
+    "node": "9.4.0"
+  },
   "scripts": {
     "start": "npm install && npm install --only=dev && node ./bin/www",
     "dev": "npm install && webpack && nodemon ./bin/www localhost 3000",


### PR DESCRIPTION
__What?__

This PR alters slightly the application setup to support CloudFoundry deployment. It also adds a new file to represent a staging environment within the
app pipeline. We then have wrapped that in a make command to automate the deployment of said application to the staging environment.

This will be revisited when we add a production environment.

__How to test__

1. Checkout this branch 
2. Ensure you have the cf cli installed (https://docs.cloud.service.gov.uk/#quick-setup-guide)
3. Login to GDS PaaS at the commandline using the cf login command
4. Ensure your local, out of version control, `.env` file is uptodate for staging environment
5. In the root directory run the make command: `make deploy-staging` 

__who can review__

Can both @frontendjim and @jok-valtech review this please? There are bits that both dev and ops need to be happy with here.